### PR TITLE
docs/feat: サマリーへのペナルティ追加とREADME追記

### DIFF
--- a/PR_PENALTY.md
+++ b/PR_PENALTY.md
@@ -1,0 +1,20 @@
+## 目的
+- 欠品/バックオーダーのペナルティコストを計上可能にし、設定JSON（デフォルト）を「全設定明示」に更新。
+
+## 変更点
+- feat(domain): BaseNode に以下を追加
+  - `stockout_cost_per_unit`（欠品1単位あたりコスト, 既定0）
+  - `backorder_cost_per_unit_per_day`（未出荷1単位×日あたりコスト, 既定0）
+- feat(engine): `penalty_costs`（`stockout`/`backorder`）を日次損益に追加し、`total_cost` に反映
+  - 欠品コスト: 当日の `shortage` × ノード単価
+  - BO保有コスト: 期末時点の未出荷（サプライヤBO/店舗顧客BO）× ノード単価
+- docs/data: `static/default_input.json` を全設定明示（lost_sales / review_period_days / penalty costs）
+- test: 追加テスト `tests/test_penalty_costs.py`（計上額と total_cost 反映の検証）
+
+## 互換性
+- 既存入力は変更不要（未指定=0計上）。
+- 既存テストはグリーン、新規テストも成功。
+
+## 確認観点
+- 欠品/BOの定義と計上タイミング（当日/期末残）
+- `penalty_costs` を `summary` へ含めるかは別PRで議論可能（現状は `total_cost` にのみ寄与）。

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -530,7 +530,10 @@ class SupplyChainSimulator:
         total_material = sum(pl.get("material_cost", 0) or 0 for pl in self.daily_profit_loss)
         total_flow = sum(sum((pl.get("flow_costs", {}) or {}).values()) for pl in self.daily_profit_loss)
         total_stock = sum(sum((pl.get("stock_costs", {}) or {}).values()) for pl in self.daily_profit_loss)
-        total_cost = total_material + total_flow + total_stock
+        total_penalty_stockout = sum(((pl.get("penalty_costs", {}) or {}).get("stockout", 0) or 0) for pl in self.daily_profit_loss)
+        total_penalty_backorder = sum(((pl.get("penalty_costs", {}) or {}).get("backorder", 0) or 0) for pl in self.daily_profit_loss)
+        total_penalty = total_penalty_stockout + total_penalty_backorder
+        total_cost = total_material + total_flow + total_stock + total_penalty
         total_profit = total_revenue - total_cost
 
         top_short = sorted(top_shortage_by_item.items(), key=lambda x: -x[1])[:5]
@@ -547,6 +550,9 @@ class SupplyChainSimulator:
             "backorder_peak_day": (backorder_total_by_day.index(max(backorder_total_by_day)) + 1) if backorder_total_by_day else 0,
             "revenue_total": total_revenue,
             "cost_total": total_cost,
+            "penalty_stockout_total": total_penalty_stockout,
+            "penalty_backorder_total": total_penalty_backorder,
+            "penalty_total": total_penalty,
             "profit_total": total_profit,
             "profit_per_day_avg": total_profit / days if days else 0,
             "top_shortage_items": [{"item": it, "shortage": qty} for it, qty in top_short],

--- a/tests/test_penalty_costs.py
+++ b/tests/test_penalty_costs.py
@@ -37,7 +37,32 @@ class TestPenaltyCosts(unittest.TestCase):
         expected_total = mat + flow + stock + 25.0
         self.assertAlmostEqual(day1.get("total_cost", 0), expected_total)
 
+    def test_penalty_in_summary(self):
+        sim_input = {
+            "planning_horizon": 1,
+            "products": [{"name": "A", "sales_price": 0, "assembly_bom": []}],
+            "nodes": [
+                {"name": "S", "node_type": "store", "initial_stock": {"A": 0}, "service_level": 0.0,
+                 "backorder_enabled": True, "lost_sales": False,
+                 "stockout_cost_per_unit": 3.0, "backorder_cost_per_unit_per_day": 2.0},
+                {"name": "W", "node_type": "warehouse", "initial_stock": {"A": 0}, "service_level": 0.0,
+                 "backorder_enabled": True},
+            ],
+            "network": [
+                {"from_node": "W", "to_node": "S", "lead_time": 3}
+            ],
+            "customer_demand": [
+                {"store_name": "S", "product_name": "A", "demand_mean": 5, "demand_std_dev": 0}
+            ],
+        }
+        sim = SupplyChainSimulator(SimulationInput(**sim_input))
+        sim.run()
+        summary = sim.compute_summary()
+        # shortage=5 -> stockout=15, backorder end-of-day=5 -> backorder=10
+        self.assertAlmostEqual(summary.get("penalty_stockout_total", 0), 15.0)
+        self.assertAlmostEqual(summary.get("penalty_backorder_total", 0), 10.0)
+        self.assertAlmostEqual(summary.get("penalty_total", 0), 25.0)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
-


### PR DESCRIPTION
サマリーにペナルティ集計（stockout/backorder/total）を追加し、READMEのスキーマ・KPI・PLDay説明を更新しました。既存・新規テストはグリーン。