### PR TITLE
fix(pl): close parentheses in PL-vs-trace assertion helper to fix CI

### DIFF
--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -1248,8 +1248,8 @@ class SupplyChainSimulator:
             revenue = float(pl.get("revenue", 0) or 0)
             total_flow = float(sum((pl.get("flow_costs", {}) or {}).values()))
             total_stock = float(sum((pl.get("stock_costs", {}) or {}).values()))
-            penalty_stockout = float(((pl.get("penalty_costs", {}) or {}).get("stockout", 0) or 0)
-            penalty_backorder = float(((pl.get("penalty_costs", {}) or {}).get("backorder", 0) or 0)
+            penalty_stockout = float(((pl.get("penalty_costs", {}) or {}).get("stockout", 0) or 0))
+            penalty_backorder = float(((pl.get("penalty_costs", {}) or {}).get("backorder", 0) or 0))
             material_cost = float(pl.get("material_cost", 0) or 0)
             total_cost = material_cost + total_flow + total_stock + penalty_stockout + penalty_backorder
             profit_loss = revenue - total_cost


### PR DESCRIPTION
CI失敗の原因である SyntaxError（閉じ括弧不足）を修正しました。\n\n- 対象: engine/simulator.py の assert_pl_equals_trace_totals 内\n- 修正: penalty_stockout / penalty_backorder の2行で括弧を閉じ忘れていたため  を追加\n- 影響: 構文エラー解消。ロジック変更なし\n\nマージ後、CIが通ることを確認ください。