### PR TITLE
feat(ui): add compare page for multiple run_ids (metrics and diffs)

### DIFF
--- a/app/ui_compare.py
+++ b/app/ui_compare.py
@@ -1,0 +1,63 @@
+from app.api import app
+from fastapi import Request, Form, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from typing import List
+
+templates = Jinja2Templates(directory="templates")
+
+
+@app.post("/ui/compare", response_class=HTMLResponse)
+def ui_compare(request: Request, run_ids: str = Form(...)):
+    ids: List[str] = [x.strip() for x in run_ids.split(",") if x.strip()]
+    if len(ids) < 2:
+        raise HTTPException(status_code=400, detail="Need 2 or more run_ids")
+
+    # 簡易実装: REGISTRY から横並び & 差分（先頭基準）
+    from app.run_registry import REGISTRY
+
+    COMPARE_KEYS = [
+        "fill_rate",
+        "revenue_total",
+        "cost_total",
+        "penalty_total",
+        "profit_total",
+        "profit_per_day_avg",
+        "store_demand_total",
+        "store_sales_total",
+        "customer_shortage_total",
+    ]
+
+    rows = []
+    for rid in ids:
+        rec = REGISTRY.get(rid)
+        if not rec:
+            raise HTTPException(status_code=404, detail=f"run not found: {rid}")
+        s = rec.get("summary") or {}
+        row = {"run_id": rid}
+        for k in COMPARE_KEYS:
+            v = s.get(k, 0.0)
+            try:
+                row[k] = float(v)
+            except Exception:
+                row[k] = None
+        rows.append(row)
+
+    diffs = []
+    if len(rows) >= 2:
+        base = rows[0]
+        for other in rows[1:]:
+            diff = {"base": base["run_id"], "target": other["run_id"]}
+            for k in COMPARE_KEYS:
+                b = base.get(k) or 0.0
+                t = other.get(k) or 0.0
+                d = t - b
+                pct = (d / b * 100.0) if b else None
+                diff[k] = {"abs": d, "pct": pct}
+            diffs.append(diff)
+
+    return templates.TemplateResponse(
+        "compare.html",
+        {"request": request, "rows": rows, "diffs": diffs, "keys": COMPARE_KEYS},
+    )
+

--- a/main.py
+++ b/main.py
@@ -35,6 +35,11 @@ try:
 except Exception:
     pass
 
+try:
+    import app.ui_compare  # noqa: F401
+except Exception:
+    pass
+
 
 __all__ = ["app", "SimulationInput", "SupplyChainSimulator"]
 

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% block content %}
+<section>
+  <h2>Compare</h2>
+  {% if rows %}
+  <h3>Metrics</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>run_id</th>
+        {% for k in keys %}<th>{{ k }}</th>{% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for r in rows %}
+      <tr>
+        <td class="mono truncate" title="{{ r.run_id }}">{{ r.run_id }}</td>
+        {% for k in keys %}
+        <td>{{ "%.4f"|format(r[k] or 0) }}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  {% if diffs %}
+  <h3>Diffs (base = {{ diffs[0].base }})</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>target</th>
+        {% for k in keys %}<th>{{ k }} (abs / %)</th>{% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for d in diffs %}
+      <tr>
+        <td class="mono">{{ d.target }}</td>
+        {% for k in keys %}
+          {% set v = d[k] %}
+          <td>{{ "%.4f"|format(v.abs or 0) }} / {% if v.pct is not none %}{{ "%.2f"|format(v.pct) }}%{% else %}-{% endif %}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+  {% else %}
+    <p>No rows.</p>
+  {% endif %}
+  <footer>
+    <a role="button" href="/ui/runs">← Back to runs</a>
+  </footer>
+</section>
+{% endblock %}
+

--- a/tests/test_ui_compare.py
+++ b/tests/test_ui_compare.py
@@ -1,0 +1,30 @@
+import importlib
+from fastapi.testclient import TestClient
+from app.api import app
+
+importlib.import_module("app.simulation_api")
+importlib.import_module("app.ui_runs")
+importlib.import_module("app.ui_compare")
+
+
+def test_ui_compare_page_roundtrip():
+    c = TestClient(app)
+    p = {
+        "planning_horizon": 2,
+        "products": [{"name": "P1", "sales_price": 100}],
+        "nodes": [{"node_type": "store", "name": "S1", "initial_stock": {"P1": 5}}],
+        "network": [],
+        "customer_demand": [
+            {"store_name": "S1", "product_name": "P1", "demand_mean": 1, "demand_std_dev": 0}
+        ],
+        "random_seed": 1,
+    }
+    id1 = c.post("/simulation", json=p).json()["run_id"]
+    p["customer_demand"][0]["demand_mean"] = 3
+    id2 = c.post("/simulation", json=p).json()["run_id"]
+    # /ui/compare は POST（フォーム）
+    r = c.post("/ui/compare", data={"run_ids": f"{id1},{id2}"})
+    assert r.status_code == 200
+    assert "Compare" in r.text
+    assert id1 in r.text and id2 in r.text
+


### PR DESCRIPTION
- /ui/compare を追加し、複数 run_id のメトリクス横並びと差分表を表示\n- app.ui_compare を副作用 import（main.py）\n- compare.html テンプレートを追加\n- 受入テスト tests/test_ui_compare.py を追加