### PR TITLE
feat(api,ui): CSV exports for results/PL/summary

### DIFF
--- a/app/trace_export_api.py
+++ b/app/trace_export_api.py
@@ -1,5 +1,7 @@
 import io
 import csv
+import json
+from typing import Any, Dict, Iterable, List, Set
 from fastapi import HTTPException, Response
 from app.api import app
 from app.run_registry import REGISTRY
@@ -32,3 +34,71 @@ def get_trace_csv(run_id: str):
         w.writerow(row)
     return Response(content=buf.getvalue(), media_type="text/csv")
 
+
+def _flatten(d: Dict[str, Any], parent: str = "", sep: str = ".") -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for k, v in (d or {}).items():
+        key = f"{parent}{sep}{k}" if parent else str(k)
+        if isinstance(v, dict):
+            out.update(_flatten(v, key, sep))
+        elif isinstance(v, (list, tuple)):
+            out[key] = json.dumps(v, ensure_ascii=False)
+        else:
+            out[key] = v
+    return out
+
+
+def _collect_fieldnames(rows: Iterable[Dict[str, Any]]) -> List[str]:
+    fields: Set[str] = set()
+    for r in rows:
+        fields.update(r.keys())
+    return ["run_id", *sorted([f for f in fields if f != "run_id"])]
+
+
+@app.get("/runs/{run_id}/results.csv")
+def get_results_csv(run_id: str):
+    rec = REGISTRY.get(run_id)
+    if not rec:
+        raise HTTPException(status_code=404, detail="run not found")
+    results = rec.get("results") or []
+    flat_rows = [_flatten(r) if isinstance(r, dict) else {"data": json.dumps(r, ensure_ascii=False)} for r in results]
+    fieldnames = _collect_fieldnames(flat_rows)
+    buf = io.StringIO()
+    w = csv.DictWriter(buf, fieldnames=fieldnames)
+    w.writeheader()
+    for r in flat_rows:
+        row = {"run_id": run_id, **r}
+        w.writerow(row)
+    return Response(content=buf.getvalue(), media_type="text/csv")
+
+
+@app.get("/runs/{run_id}/pl.csv")
+def get_pl_csv(run_id: str):
+    rec = REGISTRY.get(run_id)
+    if not rec:
+        raise HTTPException(status_code=404, detail="run not found")
+    pl = rec.get("daily_profit_loss") or []
+    flat_rows = [_flatten(r) if isinstance(r, dict) else {"data": json.dumps(r, ensure_ascii=False)} for r in pl]
+    fieldnames = _collect_fieldnames(flat_rows)
+    buf = io.StringIO()
+    w = csv.DictWriter(buf, fieldnames=fieldnames)
+    w.writeheader()
+    for r in flat_rows:
+        row = {"run_id": run_id, **r}
+        w.writerow(row)
+    return Response(content=buf.getvalue(), media_type="text/csv")
+
+
+@app.get("/runs/{run_id}/summary.csv")
+def get_summary_csv(run_id: str):
+    rec = REGISTRY.get(run_id)
+    if not rec:
+        raise HTTPException(status_code=404, detail="run not found")
+    summary = rec.get("summary") or {}
+    flat = _flatten(summary)
+    buf = io.StringIO()
+    w = csv.DictWriter(buf, fieldnames=["run_id", "metric", "value"])
+    w.writeheader()
+    for k in sorted(flat.keys()):
+        w.writerow({"run_id": run_id, "metric": k, "value": flat[k]})
+    return Response(content=buf.getvalue(), media_type="text/csv")

--- a/app/ui_compare.py
+++ b/app/ui_compare.py
@@ -3,8 +3,10 @@ from fastapi import Request, Form, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from typing import List
+from pathlib import Path
 
-templates = Jinja2Templates(directory="templates")
+_BASE_DIR = Path(__file__).resolve().parents[1]
+templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
 
 
 @app.post("/ui/compare", response_class=HTMLResponse)
@@ -60,4 +62,3 @@ def ui_compare(request: Request, run_ids: str = Form(...)):
         "compare.html",
         {"request": request, "rows": rows, "diffs": diffs, "keys": COMPARE_KEYS},
     )
-

--- a/app/ui_runs.py
+++ b/app/ui_runs.py
@@ -3,8 +3,10 @@ from fastapi import Request, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from app.run_registry import REGISTRY
+from pathlib import Path
 
-templates = Jinja2Templates(directory="templates")
+_BASE_DIR = Path(__file__).resolve().parents[1]
+templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
 
 
 @app.get("/ui/runs", response_class=HTMLResponse)

--- a/main.py
+++ b/main.py
@@ -21,22 +21,22 @@ except Exception:
     pass
 
 try:
-    import app.run_list_api  # noqa: F401
+    from app import run_list_api as _run_list_api  # noqa: F401
 except Exception:
     pass
 
 try:
-    import app.trace_export_api  # noqa: F401
+    from app import trace_export_api as _trace_export_api  # noqa: F401
 except Exception:
     pass
 
 try:
-    import app.ui_runs  # noqa: F401
+    from app import ui_runs as _ui_runs  # noqa: F401
 except Exception:
     pass
 
 try:
-    import app.ui_compare  # noqa: F401
+    from app import ui_compare as _ui_compare  # noqa: F401
 except Exception:
     pass
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -4,19 +4,29 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
-if [[ ! -f uvicorn.pid ]]; then
-  echo "[warn] uvicorn.pid が見つかりません。すでに停止している可能性があります。"
-  exit 0
-fi
+PID_FILE="uvicorn.pid"
 
-PID=$(cat uvicorn.pid)
-if ps -p "$PID" > /dev/null 2>&1; then
-  echo "[stop] killing pid $PID"
-  kill "$PID"
+if [[ -f "$PID_FILE" ]]; then
+  PID=$(cat "$PID_FILE")
+  if ps -p "$PID" > /dev/null 2>&1; then
+    echo "[stop] killing pid $PID"
+    kill "$PID" || true
+  else
+    echo "[info] pid file exists but process $PID not running"
+  fi
+  rm -f "$PID_FILE"
 else
-  echo "[info] プロセス $PID は稼働していません"
+  echo "[warn] uvicorn.pid が見つかりません。明示停止を試みます。"
 fi
 
-rm -f uvicorn.pid
-echo "[ok] 停止しました"
+# ポートで待ち受け中の uvicorn があれば停止（フォールバック）
+PORT="${PORT:-8000}"
+LISTEN_PIDS=$(ss -ltnp 2>/dev/null | awk -v p=":${PORT} " '$4 ~ p {print $NF}' | sed -n 's/.*pid=\([0-9]\+\).*/\1/p' | sort -u)
+if [[ -n "$LISTEN_PIDS" ]]; then
+  echo "[stop] killing listeners on :$PORT -> $LISTEN_PIDS"
+  for p in $LISTEN_PIDS; do
+    kill "$p" || true
+  done
+fi
 
+echo "[ok] 停止処理を完了しました"

--- a/templates/run_detail.html
+++ b/templates/run_detail.html
@@ -27,7 +27,13 @@
       <li>results: {{ counts.results_len }}</li>
       <li>daily_profit_loss: {{ counts.pl_len }}</li>
       <li>cost_trace: {{ counts.trace_len }}</li>
-      <li><a role="button" class="secondary" href="/runs/{{ run_id }}/trace.csv">Download trace.csv</a></li>
+      <li style="display:flex; gap:8px; flex-wrap:wrap; align-items:center;">
+        <span class="mono">CSV:</span>
+        <a role="button" class="secondary" href="/runs/{{ run_id }}/results.csv">results.csv</a>
+        <a role="button" class="secondary" href="/runs/{{ run_id }}/pl.csv">pl.csv</a>
+        <a role="button" class="secondary" href="/runs/{{ run_id }}/summary.csv">summary.csv</a>
+        <a role="button" class="secondary" href="/runs/{{ run_id }}/trace.csv">trace.csv</a>
+      </li>
     </ul>
   </section>
 


### PR DESCRIPTION
- API追加:\n  - GET /runs/{id}/results.csv\n  - GET /runs/{id}/pl.csv\n  - GET /runs/{id}/summary.csv (metric,value形式)\n  - 既存の /runs/{id}/trace.csv は維持\n- 実装: app/trace_export_api.py に集約（フラット化/動的ヘッダ）\n- UI: run_detail.html に results/pl/summary/trace のCSVリンクを追加\n\n備考:\n- ネスト辞書は dot 区切りでフラット化、配列は JSON 文字列化\n- レコードが空の場合でもヘッダのみでCSVを返却