### PR TITLE
feat: 非同期ジョブMVP（/jobs submit/list/get + ワーカー + DB）

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -123,6 +123,7 @@ def validate_input(input_data: SimulationInput) -> None:
 
 
 from app.metrics import observe_http
+from app.jobs import JOB_MANAGER
 
 
 class _RequestIDMiddleware(BaseHTTPMiddleware):
@@ -220,3 +221,19 @@ async def get_summary():
             status_code=404, detail="No summary available yet. Run a simulation first."
         )
     return _LAST_SUMMARY
+
+
+@app.on_event("startup")
+async def _start_jobs():
+    try:
+        JOB_MANAGER.start()
+    except Exception:
+        logging.exception("failed to start JobManager")
+
+
+@app.on_event("shutdown")
+async def _stop_jobs():
+    try:
+        JOB_MANAGER.stop()
+    except Exception:
+        logging.exception("failed to stop JobManager")

--- a/app/jobs.py
+++ b/app/jobs.py
@@ -1,0 +1,137 @@
+import threading
+import queue
+import time
+import json
+from uuid import uuid4
+from typing import Any, Dict, Optional
+import os
+
+from domain.models import SimulationInput
+from engine.simulator import SupplyChainSimulator
+from app.run_registry import REGISTRY
+from app import db
+from prometheus_client import Counter as _Counter, Histogram as _Histogram
+
+
+JOBS_ENABLED = os.getenv("JOBS_ENABLED", "1") == "1"
+JOBS_WORKERS = int(os.getenv("JOBS_WORKERS", "1") or 1)
+
+JOBS_ENQUEUED = _Counter("jobs_enqueued_total", "Total jobs enqueued", labelnames=("type",))
+JOBS_COMPLETED = _Counter("jobs_completed_total", "Total jobs completed", labelnames=("type",))
+JOBS_FAILED = _Counter("jobs_failed_total", "Total jobs failed", labelnames=("type",))
+JOBS_DURATION = _Histogram(
+    "jobs_duration_seconds",
+    "Job execution duration in seconds",
+    labelnames=("type",),
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, float("inf")),
+)
+
+
+class JobManager:
+    def __init__(self, workers: int = 1):
+        self.workers = max(1, workers)
+        self.q: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+        self._threads: list[threading.Thread] = []
+        self._stop = threading.Event()
+
+    def start(self):
+        if self._threads:
+            return
+        for i in range(self.workers):
+            t = threading.Thread(target=self._run_loop, name=f"job-worker-{i}", daemon=True)
+            t.start()
+            self._threads.append(t)
+
+    def stop(self, timeout: float = 2.0):
+        self._stop.set()
+        try:
+            while not self.q.empty():
+                try:
+                    self.q.get_nowait()
+                except Exception:
+                    break
+        except Exception:
+            pass
+        for t in self._threads:
+            t.join(timeout)
+        self._threads.clear()
+
+    def submit_simulation(self, payload: Dict[str, Any]) -> str:
+        if not self._threads:
+            self.start()
+        job_id = uuid4().hex
+        now = int(time.time() * 1000)
+        db.create_job(job_id, "simulation", "queued", now, json.dumps(payload, ensure_ascii=False))
+        self.q.put({"job_id": job_id, "type": "simulation"})
+        try:
+            JOBS_ENQUEUED.labels(type="simulation").inc()
+        except Exception:
+            pass
+        return job_id
+
+    def _run_loop(self):
+        while not self._stop.is_set():
+            try:
+                job = self.q.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            job_id = job.get("job_id")
+            jtype = job.get("type")
+            if jtype == "simulation":
+                self._run_simulation(job_id)
+            else:
+                # unknown type: mark failed
+                db.update_job_status(job_id, status="failed", finished_at=int(time.time() * 1000), error="unknown job type")
+                try:
+                    JOBS_FAILED.labels(type=jtype or "unknown").inc()
+                except Exception:
+                    pass
+
+    def _run_simulation(self, job_id: str):
+        started = int(time.time() * 1000)
+        db.update_job_status(job_id, status="running", started_at=started)
+        t0 = time.monotonic()
+        try:
+            rec = db.get_job(job_id)
+            payload = json.loads(rec.get("params_json") or "{}") if rec else {}
+            # parse model
+            sim_input = SimulationInput(**payload)
+            sim = SupplyChainSimulator(sim_input)
+            results, daily_pl = sim.run()
+            try:
+                summary = sim.compute_summary()
+            except Exception:
+                summary = {}
+            run_id = uuid4().hex
+            # store to registry (same as /simulation)
+            REGISTRY.put(
+                run_id,
+                {
+                    "run_id": run_id,
+                    "started_at": started,
+                    "duration_ms": int((time.monotonic() - t0) * 1000),
+                    "schema_version": getattr(sim_input, "schema_version", "1.0"),
+                    "summary": summary,
+                    "results": results,
+                    "daily_profit_loss": daily_pl,
+                    "cost_trace": getattr(sim, "cost_trace", []),
+                },
+            )
+            finished = int(time.time() * 1000)
+            db.update_job_status(job_id, status="succeeded", finished_at=finished, run_id=run_id)
+            try:
+                JOBS_COMPLETED.labels(type="simulation").inc()
+                JOBS_DURATION.labels(type="simulation").observe(time.monotonic() - t0)
+            except Exception:
+                pass
+        except Exception as e:
+            finished = int(time.time() * 1000)
+            db.update_job_status(job_id, status="failed", finished_at=finished, error=str(e))
+            try:
+                JOBS_FAILED.labels(type="simulation").inc()
+            except Exception:
+                pass
+
+
+# singleton manager (workers will be started on app startup)
+JOB_MANAGER = JobManager(workers=JOBS_WORKERS)

--- a/app/jobs_api.py
+++ b/app/jobs_api.py
@@ -1,0 +1,29 @@
+from typing import Any, Dict
+import json
+import time
+from uuid import uuid4
+
+from fastapi import Body, HTTPException, Query
+from app.api import app
+from app.jobs import JOB_MANAGER
+from app import db
+
+
+@app.post("/jobs/simulation")
+def post_job_simulation(body: Dict[str, Any] = Body(...)):
+    job_id = JOB_MANAGER.submit_simulation(body)
+    return {"job_id": job_id}
+
+
+@app.get("/jobs/{job_id}")
+def get_job(job_id: str):
+    row = db.get_job(job_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="job not found")
+    return row
+
+
+@app.get("/jobs")
+def list_jobs(status: str | None = Query(None), offset: int = Query(0, ge=0), limit: int = Query(50, ge=1, le=200)):
+    return db.list_jobs(status, offset, limit)
+

--- a/tests/test_jobs_simulation.py
+++ b/tests/test_jobs_simulation.py
@@ -1,0 +1,41 @@
+import importlib
+import time
+from fastapi.testclient import TestClient
+
+importlib.import_module("app.jobs_api")
+importlib.import_module("app.simulation_api")
+
+from app.api import app
+from domain.models import SimulationInput, Product, StoreNode, CustomerDemand
+
+
+def _payload():
+    return SimulationInput(
+        planning_horizon=2,
+        products=[Product(name="P1", sales_price=100.0)],
+        nodes=[StoreNode(name="S1", initial_stock={"P1": 0})],
+        network=[],
+        customer_demand=[CustomerDemand(store_name="S1", product_name="P1", demand_mean=0, demand_std_dev=0)],
+        random_seed=1,
+    )
+
+
+def test_jobs_simulation_end_to_end():
+    client = TestClient(app)
+    # enqueue
+    r = client.post("/jobs/simulation", json=_payload().model_dump())
+    assert r.status_code == 200
+    job_id = r.json()["job_id"]
+    # poll
+    status = None
+    for _ in range(50):
+        g = client.get(f"/jobs/{job_id}")
+        assert g.status_code == 200
+        body = g.json()
+        status = body["status"]
+        if status in ("succeeded", "failed"):
+            break
+        time.sleep(0.05)
+    assert status == "succeeded"
+    assert body.get("run_id")
+


### PR DESCRIPTION
目的\n- 長時間処理の基盤化と将来のTimeBucket/予測/最適化ジョブ化の土台\n\n変更点\n- DB: jobsテーブル追加（job_id/type/status/timestamps/params_json/run_id/error + 索引）\n- ランタイム: インメモリキュー+スレッドワーカー、起動時に開始・submit時にlazy start\n- API: POST /jobs/simulation, GET /jobs/{id}, GET /jobs?status&offset&limit\n- 統合: シミュレーション実行をワーカーで実施し、RunRegistryへ保存→jobs.run_idに紐付け\n- 観測性: jobs_enqueued_total/jobs_completed_total/jobs_failed_total/jobs_duration_seconds\n- テスト: E2E（enqueue→poll→succeeded）最小ケース追加\n\n互換\n- 既存の POST /simulation は従来通り（変更なし）\n\nマージ\n- 自動マージ（squash）を有効化します。