### PR TITLE
feat: ジョブ一覧/詳細UIの追加（/ui/jobs）

### DIFF
--- a/app/ui_jobs.py
+++ b/app/ui_jobs.py
@@ -1,0 +1,38 @@
+from app.api import app
+from fastapi import Request, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from pathlib import Path
+from app import db
+
+_BASE_DIR = Path(__file__).resolve().parents[1]
+templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
+
+
+@app.get("/ui/jobs", response_class=HTMLResponse)
+def ui_jobs(request: Request, status: str | None = None, offset: int = 0, limit: int = 20):
+    data = db.list_jobs(status, offset, limit)
+    return templates.TemplateResponse(
+        "jobs.html",
+        {
+            "request": request,
+            "rows": data.get("jobs", []),
+            "total": data.get("total", 0),
+            "offset": data.get("offset", 0),
+            "limit": data.get("limit", limit),
+            "status": status or "",
+            "subtitle": "Jobs",
+        },
+    )
+
+
+@app.get("/ui/jobs/{job_id}", response_class=HTMLResponse)
+def ui_job_detail(request: Request, job_id: str):
+    row = db.get_job(job_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="job not found")
+    return templates.TemplateResponse(
+        "job_detail.html",
+        {"request": request, "job": row, "subtitle": "Jobs"},
+    )
+

--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
         <h1>サプライチェーンシミュレーション</h1>
         <div class="nav-actions">
             <a class="nav-link" href="/ui/runs" title="ラン履歴" target="_blank" rel="noopener noreferrer">ラン履歴</a>
+            <a class="nav-link" href="/ui/jobs" title="ジョブ一覧" target="_blank" rel="noopener noreferrer">ジョブ一覧</a>
             <a class="nav-link" href="/ui/configs" title="設定マスタ" target="_blank" rel="noopener noreferrer">設定マスタ</a>
             <button class="run-button">シミュレーション実行</button>
         </div>

--- a/templates/job_detail.html
+++ b/templates/job_detail.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block content %}
+<article>
+  <header>
+    <h2>Job Detail</h2>
+    <p class="mono">{{ job.job_id }}</p>
+  </header>
+  <section>
+    <table>
+      <tbody>
+        <tr><th>type</th><td>{{ job.type }}</td></tr>
+        <tr><th>status</th><td>{{ job.status }}</td></tr>
+        <tr><th>submitted_at</th><td>{{ job.submitted_at }}</td></tr>
+        <tr><th>started_at</th><td>{{ job.started_at or '' }}</td></tr>
+        <tr><th>finished_at</th><td>{{ job.finished_at or '' }}</td></tr>
+        <tr><th>run_id</th><td class="mono">{% if job.run_id %}<a href="/ui/runs/{{ job.run_id }}">{{ job.run_id }}</a>{% endif %}</td></tr>
+        <tr><th>error</th><td><pre>{{ job.error or '' }}</pre></td></tr>
+      </tbody>
+    </table>
+  </section>
+  <footer>
+    <a role="button" href="/ui/jobs">← Back to jobs</a>
+  </footer>
+</article>
+{% endblock %}
+

--- a/templates/jobs.html
+++ b/templates/jobs.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block content %}
+<section>
+  <h2>Jobs</h2>
+  <form method="get" action="/ui/jobs" style="display:flex; gap:8px; align-items:center; margin:8px 0;">
+    <label>Status
+      <select name="status">
+        <option value="" {% if not status %}selected{% endif %}>(all)</option>
+        {% for s in ["queued","running","succeeded","failed"] %}
+        <option value="{{ s }}" {% if status == s %}selected{% endif %}>{{ s }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <button type="submit" class="secondary">Apply</button>
+  </form>
+  {% if rows %}
+  <table role="grid">
+    <thead>
+      <tr>
+        <th>job_id</th>
+        <th>type</th>
+        <th>status</th>
+        <th>submitted_at</th>
+        <th>started_at</th>
+        <th>finished_at</th>
+        <th>run_id</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for r in rows %}
+      <tr>
+        <td class="mono truncate" title="{{ r.job_id }}">{{ r.job_id }}</td>
+        <td>{{ r.type }}</td>
+        <td>{{ r.status }}</td>
+        <td>{{ r.submitted_at }}</td>
+        <td>{{ r.started_at or '' }}</td>
+        <td>{{ r.finished_at or '' }}</td>
+        <td class="mono truncate" title="{{ r.run_id }}">{{ r.run_id or '' }}</td>
+        <td><a role="button" href="/ui/jobs/{{ r.job_id }}">Detail</a></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>No jobs.</p>
+  {% endif %}
+  <div style="margin-top:8px; display:flex; gap:8px; align-items:center;">
+    {% set prev = (offset - limit) if (offset - limit) > 0 else 0 %}
+    {% set next = (offset + limit) if (offset + limit) < total else offset %}
+    <a role="button" class="secondary" href="/ui/jobs?status={{ status }}&offset={{ prev }}&limit={{ limit }}">Prev</a>
+    <a role="button" class="secondary" href="/ui/jobs?status={{ status }}&offset={{ next }}&limit={{ limit }}">Next</a>
+    <span class="mono">{{ offset + 1 if total else 0 }}-{{ (offset + limit) if (offset + limit) < total else total }} / {{ total }}</span>
+  </div>
+</section>
+{% endblock %}
+


### PR DESCRIPTION
概要\n- UI: /ui/jobs（一覧/ページング/ステータスフィルタ）, /ui/jobs/{id}（詳細）を追加\n- ナビ: indexヘッダに『ジョブ一覧』リンクを追加\n\n互換\n- 既存機能非破壊（新規ページのみ）\n\n確認\n- jobs MVPでenqueue後、/ui/jobs から状態・Runリンクを確認可能\n\nマージ\n- 自動マージ（squash）を設定します。