### PR TITLE
fix: CI#546 修正（runs容量・シナリオテーブル・REGISTRY参照）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # サプライチェーン計画シミュレーション
 
-[![CI](https://github.com/miumigy/scpln/actions/workflows/ci.yml/badge.svg)](https://github.com/miumigy/scpln/actions/workflows/ci.yml)
+[![CI](https://github.com/miumigy/scpln/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/miumigy/scpln/actions/workflows/ci.yml)
 
 サプライチェーン（店舗/倉庫/工場/資材）をノード/リンクで記述し、需要伝播・在庫/生産・コスト計上を日次でシミュレートします。RunRegistry に実行履歴を保持し、UI から履歴参照・比較・CSVエクスポートが可能です。
 

--- a/app/db.py
+++ b/app/db.py
@@ -102,6 +102,25 @@ def init_db() -> None:
             c.execute("ALTER TABLE jobs ADD COLUMN result_json TEXT")
         except Exception:
             pass
+        # scenarios テーブル（存在しない環境への後方互換）
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS scenarios (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                parent_id INTEGER,
+                tag TEXT,
+                description TEXT,
+                locked INTEGER NOT NULL DEFAULT 0,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            )
+            """
+        )
+        try:
+            c.execute("CREATE INDEX IF NOT EXISTS idx_scenarios_parent ON scenarios(parent_id)")
+        except Exception:
+            pass
         # hierarchy master tables
         c.execute(
             """


### PR DESCRIPTION
- DB初期化でscenariosテーブルを作成（後方互換）
- /runsエンドポイントでDBバックエンド時にRUNS_DB_MAX_ROWSに基づくクリーンアップを実行
- REGISTRYを動的取得に変更し、テスト中の環境切替に追従

これにより tests/test_runs_persistence.py と scenarios系UIテストの失敗を解消します。