### PR TITLE
fix: planning出力の配信とJobs表示改善（/outマウント・out_dirリンク）

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -90,6 +90,8 @@ _configure_logging()
 app = FastAPI()
 BASE_DIR = Path(__file__).resolve().parents[1]
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
+# Planning出力（/out 配下）を静的配信
+app.mount("/out", StaticFiles(directory=str(BASE_DIR / "out")), name="out")
 
 # Cache last summary for GET /summary
 _LAST_SUMMARY = None
@@ -256,6 +258,7 @@ class _AuthMiddleware(BaseHTTPMiddleware):
         path = request.url.path or ""
         if (
             path.startswith("/static/")
+            or path.startswith("/out/")
             or path.startswith("/ui/")
             or path
             in ("/healthz", "/", "/index.html", "/__debug/index", "/openapi.json")

--- a/app/ui_jobs.py
+++ b/app/ui_jobs.py
@@ -15,11 +15,22 @@ def ui_jobs(
     request: Request, status: str | None = None, offset: int = 0, limit: int = 20
 ):
     data = db.list_jobs(status, offset, limit)
+    rows = data.get("jobs", [])
+    # planningの結果(out_dir)を抽出し、テンプレートで使いやすくする
+    import json as _json
+    for r in rows:
+        try:
+            if r.get("type") == "planning" and r.get("result_json"):
+                js = _json.loads(r.get("result_json"))
+                if isinstance(js, dict) and js.get("out_dir"):
+                    r["out_dir"] = js.get("out_dir")
+        except Exception:
+            pass
     return templates.TemplateResponse(
         "jobs.html",
         {
             "request": request,
-            "rows": data.get("jobs", []),
+            "rows": rows,
             "total": data.get("total", 0),
             "offset": data.get("offset", 0),
             "limit": data.get("limit", limit),

--- a/templates/jobs.html
+++ b/templates/jobs.html
@@ -94,7 +94,7 @@
         <th>submitted_at</th>
         <th>started_at</th>
         <th>finished_at</th>
-        <th>run_id</th>
+        <th>run_id / output</th>
         <th></th>
         <th></th>
       </tr>
@@ -108,7 +108,15 @@
         <td class="ts-ms" data-ms="{{ r.submitted_at }}">{{ r.submitted_at }}</td>
         <td class="ts-ms" data-ms="{{ r.started_at or '' }}">{{ r.started_at or '' }}</td>
         <td class="ts-ms" data-ms="{{ r.finished_at or '' }}">{{ r.finished_at or '' }}</td>
-        <td class="mono truncate" title="{{ r.run_id }}">{{ r.run_id or '' }}</td>
+        <td class="mono truncate" title="{{ r.run_id or r.out_dir or '' }}">
+          {% if r.run_id %}
+            {{ r.run_id }}
+          {% elif r.type == 'planning' and r.out_dir %}
+            <a href="/ui/planning?dir={{ r.out_dir }}">{{ r.out_dir }}</a>
+          {% else %}
+            
+          {% endif %}
+        </td>
         <td>
           {% if r.job_id %}
           <a role="button" href="/ui/jobs/{{ r.job_id }}">Detail</a>


### PR DESCRIPTION
概要:\n- planningパイプライン実行後の成果物（report.csv等）が配信されず可視化も動作しなかったため、/out を静的配信としてマウントしました。\n- Jobs一覧でplanningジョブのrun_idが空だったため、result_jsonのout_dirを抽出し、/ui/planning?dir=... へのリンクとして表示しました。\n\n変更点:\n- app/api.py: /out を StaticFiles でマウント、AUTHバイパス対象へ追加\n- app/ui_jobs.py: planningジョブの out_dir を行データに展開\n- templates/jobs.html: 『run_id / output』列にout_dirリンクを表示（planningのみ）\n\n影響範囲:\n- /out配下の静的配信が有効化され、/ui/planning のreport.csvダウンロードと可視化fetchが成功します。\n- 既存API/UIへの破壊的変更はありません。\n\n確認手順:\n1) /ui/planning でパイプライン実行\n2) 結果ページで表とグラフが表示され、report.csvがダウンロードできる\n3) /ui/jobs で planning ジョブの『run_id / output』に /ui/planning へのリンクが表示される\n