### PR TITLE
fix: Planning表示の堅牢化と/out配信保証（結果表示・可視化・DL改善）

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -89,6 +89,9 @@ _configure_logging()
 
 app = FastAPI()
 BASE_DIR = Path(__file__).resolve().parents[1]
+# 静的配信ディレクトリの存在を保証
+(BASE_DIR / "static").mkdir(parents=True, exist_ok=True)
+(BASE_DIR / "out").mkdir(parents=True, exist_ok=True)
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 # Planning出力（/out 配下）を静的配信
 app.mount("/out", StaticFiles(directory=str(BASE_DIR / "out")), name="out")


### PR DESCRIPTION
概要:\n- /ui/planning の結果表示が不安定（読込失敗で全体不表示）だったため、個別読込＋部分表示に変更。\n- report.csv の配信/可視化が不安定なケースへ対処（/outディレクトリの存在保証、相対パス構築）。\n\n変更点:\n- app/ui_planning.py: 各JSON（aggregate/sku_week/mrp/plan_final）を個別に読込。存在しない場合はエラーを蓄積しつつ他の表示を継続。report.csvは存在有無に関わらず相対パスを構築し、DL/可視化が試行可能に。\n- app/api.py: 起動時に /static と /out をmkdir（存在保証）。StaticFilesマウントの失敗や配信不能を回避。\n\n効果:\n- パイプライン実行後、表とグラフの表示・report.csv ダウンロードが安定化。\n- 一部生成物が欠落しても、利用可能な結果だけ先に可視化可能。\n\n確認手順:\n1) /ui/planning で『パイプライン実行』→ /ui/planning?dir=... に遷移\n2) Aggregate/能力サマリ/MRP表のいずれかが表示（生成状況に応じて）。エラーメッセージはページ上部に表示\n3) report.csv がダウンロードでき、グラフが描画される\n