### PR TITLE
fix: Homeと他画面のUI統一（ナビ日本語化・PicoCSS適用）

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>サプライチェーンシミュレーション (拡張版)</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@2/css/pico.min.css">
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 0; background-color: #f0f2f5; color: #333; }
         .navbar { background-color: #fff; color: #333; padding: 0 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #ddd; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
@@ -47,27 +49,35 @@
     </style>
 </head>
 <body>
-    <div class="navbar">
-        <h1>サプライチェーンシミュレーション</h1>
-        <div class="nav-actions">
-            <a class="nav-link" href="/ui/runs" title="ラン履歴">ラン履歴</a>
-            <a class="nav-link" href="/ui/scenarios" title="シナリオ一覧">シナリオ一覧</a>
-            <a class="nav-link" href="/ui/configs" title="設定マスタ">設定マスタ</a>
-            <a class="nav-link" href="/ui/jobs" title="ジョブ一覧">ジョブ一覧</a>
-            <a class="nav-link" href="/ui/hierarchy" title="階層マスタ">階層マスタ</a>
-            <a class="nav-link" href="/ui/planning" title="集約/詳細計画">集約/詳細計画</a>
-            <form id="api-key-form" style="display:flex; align-items:center; gap:6px; font-weight:normal; margin:0;" onsubmit="return false;">
-              <label style="display:flex; align-items:center; gap:6px; font-weight:normal;">
-                API Key
-                <input id="api-key-input" type="password" placeholder="X-API-Key" style="width:12em;" autocomplete="current-password" />
-              </label>
-              <button id="api-key-save" class="secondary" style="padding:6px 10px;" type="button">保存</button>
-            </form>
-            <button id="run-button" class="run-button">シミュレーション実行</button>
+    <main class="container">
+      <header>
+        <hgroup>
+          <h1>サプライチェーンシミュレーション</h1>
+          <p class="mono">Home</p>
+        </hgroup>
+        <nav style="display:flex; gap:10px; flex-wrap:wrap;">
+          <a href="/">Home</a>
+          <a href="/ui/runs">ラン履歴</a>
+          <a href="/ui/scenarios">シナリオ一覧</a>
+          <a href="/ui/configs">設定マスタ</a>
+          <a href="/ui/jobs">ジョブ一覧</a>
+          <a href="/ui/hierarchy">階層マスタ</a>
+          <a href="/ui/planning">集約/詳細計画</a>
+        </nav>
+        <div class="nav-actions" style="display:flex; align-items:center; gap:12px;">
+          <form id="api-key-form" style="display:flex; align-items:center; gap:6px; font-weight:normal; margin:0;" onsubmit="return false;">
+            <label style="display:flex; align-items:center; gap:6px; font-weight:normal;">
+              API Key
+              <input id="api-key-input" type="password" placeholder="X-API-Key" style="width:12em;" autocomplete="current-password" />
+            </label>
+            <button id="api-key-save" class="secondary" style="padding:6px 10px;" type="button">保存</button>
+          </form>
+          <button id="run-button" class="run-button">シミュレーション実行</button>
         </div>
-    </div>
+      </header>
+    </main>
 
-    <div class="main-container">
+    <div class="main-container container">
         <div class="tab-bar">
             <button class="tab-button active" data-tab="config">設定JSON</button>
             <button class="tab-button" data-tab="results">実行結果</button>

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,11 +22,12 @@
       </hgroup>
       <nav style="display:flex; gap:10px; flex-wrap:wrap;">
         <a href="/">Home</a>
-        <a href="/ui/runs">Runs</a>
-        <a href="/ui/scenarios">Scenarios</a>
-        <a href="/ui/configs">Configs</a>
-        <a href="/ui/jobs">Jobs</a>
-        <a href="/ui/planning">Planning</a>
+        <a href="/ui/runs">ラン履歴</a>
+        <a href="/ui/scenarios">シナリオ一覧</a>
+        <a href="/ui/configs">設定マスタ</a>
+        <a href="/ui/jobs">ジョブ一覧</a>
+        <a href="/ui/hierarchy">階層マスタ</a>
+        <a href="/ui/planning">集約/詳細計画</a>
       </nav>
     </header>
     {% block content %}{% endblock %}


### PR DESCRIPTION
概要:\n- Home（index.html）と/ui配下の画面（templates/base.html）でUIの見た目・ナビ文言が異なっていたため統一しました。\n\n変更点:\n- templates/base.html: ナビゲーションを日本語化し、『階層マスタ』『集約/詳細計画』を追加\n- index.html: PicoCSSを導入し、ヘッダ/ナビ構造をbase.html準拠へ。Home/ラン履歴/シナリオ一覧/設定マスタ/ジョブ一覧/階層マスタ/集約/詳細計画の同一構成に変更\n\n効果:\n- Homeと他画面でナビとスタイルが揃い、UI体験が統一されます。\n\n確認手順:\n1) / を開き、ヘッダ/ナビの見た目・文言が/ui配下と一致すること\n2) /ui/runs 等へ遷移し、ナビ文言が日本語で統一されていること\n