### PR TITLE
fix: Homeのボタン青色を他画面と統一（#0d6efd）

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,8 +33,9 @@
             background-color: #e9ecef; /* Apply background to header cells */
         }
 
-        .run-button { background-color: #007bff; color: white; border: none; border-radius: 5px; padding: 10px 20px; font-size: 1em; cursor: pointer; transition: background-color 0.2s ease; }
-        .run-button:hover { background-color: #0056b3; }
+        /* ボタン色を他画面と統一（Picoのプライマリ相当） */
+        .run-button { background-color: #0d6efd; color: white; border: none; border-radius: 5px; padding: 10px 20px; font-size: 1em; cursor: pointer; transition: background-color 0.2s ease; }
+        .run-button:hover { background-color: #0b5ed7; }
         .nav-actions { display:flex; align-items:center; gap:12px; }
         .nav-link { color:#007bff; text-decoration:none; font-weight:600; }
         .nav-link:hover { text-decoration:underline; }


### PR DESCRIPTION
概要:\n- Home画面のカスタムボタン色（#007bff）が/uiのスタイルと異なっていたため統一しました。\n\n変更点:\n- index.html: .run-button を #0d6efd（ホバー #0b5ed7）に変更し、PicoCSSのプライマリと整合\n\n確認手順:\n1) / を開き『シミュレーション実行』ボタンの青が/ui配下のボタン色と一致すること\n