### PR TITLE
fix: Homeタブのホバーカラー統一（Pico系ブルー）

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
         .main-container { padding: 20px; }
         .tab-bar { display: flex; border-bottom: 1px solid #ddd; }
         .tab-button { padding: 10px 20px; cursor: pointer; background-color: #fff; color:#111; border: 1px solid #ddd; border-bottom: 3px solid transparent; font-size: 1em; transition: all 0.2s ease; }
+        .tab-button:hover { color:#0b5ed7; background-color:#f8f9fa; }
+        .tab-button:focus-visible { outline: 2px solid #0d6efd55; outline-offset: 2px; }
         .tab-button.active { border-bottom: 3px solid #0d6efd; font-weight: bold; background-color: #fff; color:#0d6efd; }
         .tab-content { display: none; padding: 20px; background-color: #fff; border: 1px solid #ddd; border-top: none; border-radius: 0 0 8px 8px; }
         .tab-content.active { display: block; }


### PR DESCRIPTION
概要:\n- Homeのタブにホバー時の色指定がなく、他画面とトーン差が出ていたため統一しました。\n\n変更点:\n- index.html: .tab-button:hover に文字色 #0b5ed7 / 背景 #f8f9fa を追加\n- :focus-visible のアウトラインも追加しアクセシビリティ向上\n\n効果:\n- ホバー時の色がPicoのプライマリ系と調和し、視認性と統一感が向上\n\n確認手順:\n1) / でタブにマウスオーバーし、色がブルー系に変化すること\n2) キーボードでフォーカス移動し、アウトラインが表示されること\n