### PR TITLE
ci: GitHubリリースでRender自動デプロイ対応

### DIFF
--- a/.github/workflows/deploy-render.yml
+++ b/.github/workflows/deploy-render.yml
@@ -1,0 +1,40 @@
+name: Deploy to Render on Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Trigger Render Deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger via Render API (preferred)
+        if: ${{ secrets.RENDER_API_KEY && secrets.RENDER_SERVICE_ID }}
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+        run: |
+          set -euo pipefail
+          echo "Triggering deploy for service $RENDER_SERVICE_ID via Render API"
+          curl -fsS \
+            -H "Authorization: Bearer ${RENDER_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys" \
+            -d '{"clearCache":false}'
+
+      - name: Trigger via Deploy Hook (fallback)
+        if: ${{ !secrets.RENDER_API_KEY || !secrets.RENDER_SERVICE_ID }}
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RENDER_DEPLOY_HOOK_URL:-}" ]; then
+            echo "Missing secret RENDER_DEPLOY_HOOK_URL or (RENDER_API_KEY & RENDER_SERVICE_ID)." >&2
+            exit 1
+          fi
+          echo "Triggering deploy via Deploy Hook"
+          curl -fsS -X POST "$RENDER_DEPLOY_HOOK_URL"
+

--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ bash scripts/stop.sh            # 停止
 - Freeプランではスリープやビルド時間制限があります。スリープ復帰時の初回応答が遅くなることがあります。
 - ディスク容量は用途に応じて調整してください。`/out` に可視化用CSV（`report.csv`）や`/ui/planning`の生成物が保存されます。
 - 認証は既定で無効（`AUTH_MODE=none`）です。公開環境では `AUTH_MODE=apikey|basic` とシークレットを設定してください。
+
+### GitHubリリース作成で自動デプロイ
+
+リリース公開（Release published）をトリガにRenderへデプロイを行うGitHub Actionsを追加しています（`.github/workflows/deploy-render.yml`）。
+
+事前準備（GitHub Secrets いずれか）:
+- 推奨: `RENDER_API_KEY` と `RENDER_SERVICE_ID`（Render APIでDeployを作成）
+  - API Key: Renderダッシュボード → Account → API Keys で作成
+  - Service ID: 対象サービスの詳細ページURLに含まれる `srv-...`
+- 代替: `RENDER_DEPLOY_HOOK_URL`（Deploy Hookで再デプロイ）
+  - サービス詳細 → Deploy hooks → 生成したURLをSecretに設定
+
+動作:
+- Release published または 手動実行（workflow_dispatch）で起動
+- `RENDER_API_KEY`/`RENDER_SERVICE_ID` があればAPI経由でデプロイ、無ければ `RENDER_DEPLOY_HOOK_URL` にPOSTします
+
+注意:
+- Deploy Hookはサービス設定のブランチ最新をデプロイします（タグ固定は不可）。特定タグのデプロイが必要な場合は、Render APIの高度な設定をご利用ください。
 永続化: `.env` に `SCPLN_DB=data/scpln.db` や `RUNS_DB_MAX_ROWS=1000` を設定可能。未設定でも `scripts/serve.sh` によりRunRegistryはDBバックエンド（REGISTRY_BACKEND=db）で起動します。
 
 ### 環境変数とシークレットの扱い（重要）


### PR DESCRIPTION
概要:\n- GitHubリリース作成（published）をトリガに、Renderへデプロイを自動実行します。\n\n内容:\n- .github/workflows/deploy-render.yml を追加。Render API (RENDER_API_KEY/RENDER_SERVICE_ID) か Deploy Hook (RENDER_DEPLOY_HOOK_URL) のどちらかでトリガ\n- READMEにSecrets設定手順と注意点を追記\n\n運用手順:\n- GitHub Secretsに下記を設定\n  * 推奨: RENDER_API_KEY, RENDER_SERVICE_ID\n  * 代替: RENDER_DEPLOY_HOOK_URL\n- リリースをpublishすると、Renderがデプロイされます（workflow_dispatchで手動実行も可）\n