### PR TITLE
fix(ui): プラン一覧のCreated at表記統一とcutover/window/policy表示補完

### DIFF
--- a/app/ui_plans.py
+++ b/app/ui_plans.py
@@ -24,7 +24,18 @@ def ui_plans(request: Request):
         summary = (recon or {}).get("summary") or {}
         cut = (recon or {}).get("cutover") or {}
         policy = cut.get("anchor_policy")
-        rows.append({**p, "recon_summary": summary, "policy": policy})
+        # DBに保存されていない場合は、artifactのcutover情報で補完
+        cutover_date = p.get("cutover_date") or cut.get("cutover_date")
+        recon_window_days = p.get("recon_window_days")
+        if recon_window_days is None:
+            recon_window_days = cut.get("recon_window_days")
+        rows.append({
+            **p,
+            "cutover_date": cutover_date,
+            "recon_window_days": recon_window_days,
+            "recon_summary": summary,
+            "policy": policy,
+        })
     return templates.TemplateResponse(
         "plans.html",
         {

--- a/templates/plans.html
+++ b/templates/plans.html
@@ -25,7 +25,7 @@
         <td class="mono">{{ p.cutover_date or '' }}</td>
         <td class="mono">{{ p.recon_window_days or '' }}</td>
         <td class="mono">{{ p.policy or '' }}</td>
-        <td class="mono">{{ p.created_at }}</td>
+        <td class="mono ts-ms" data-ms="{{ p.created_at }}">{{ p.created_at }}</td>
         <td class="mono">{{ (p.recon_summary.violations or p.recon_summary.tol_violations) if p.recon_summary else '' }}</td>
         <td class="mono">
           {% if p.recon_summary and p.recon_summary.max_abs_delta %}
@@ -45,4 +45,28 @@
   <p>まだプランがありません。/ui/planning から実行するか、/plans/integrated/run を呼び出してください。</p>
   {% endif %}
 </section>
+{% endblock %}
+{% block scripts %}
+<script>
+// JSTフォーマット（ms epoch → YYYY/MM/DD HH:mm:ss）
+function fmtJst(ms){
+  var n = Number(ms);
+  if (!Number.isFinite(n)) return '';
+  var t = new Date(n + 9*3600*1000); // JSTへシフトしUTC系getterで整形
+  var y = t.getUTCFullYear();
+  var mo = String(t.getUTCMonth()+1).padStart(2,'0');
+  var d = String(t.getUTCDate()).padStart(2,'0');
+  var h = String(t.getUTCHours()).padStart(2,'0');
+  var mi = String(t.getUTCMinutes()).padStart(2,'0');
+  var s = String(t.getUTCSeconds()).padStart(2,'0');
+  return y+'/'+mo+'/'+d+' '+h+':'+mi+':'+s;
+}
+document.addEventListener('DOMContentLoaded', function(){
+  document.querySelectorAll('td.ts-ms').forEach(function(td){
+    var ms = td.getAttribute('data-ms');
+    var txt = fmtJst(ms);
+    if (txt) td.textContent = txt;
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
変更点:\n- plans.html: created_at を ms→JST フォーマット（YYYY/MM/DD HH:mm:ss）に整形\n- ui_plans.py: reconciliation_log.json.cutover から cutover_date/recon_window_days/anchor_policy を補完\n\n背景:\n- 一覧のCreated atがミリ秒のままで他画面と不一致\n- DB未保存ケースでcutover/window/policyが空表示\n\n影響範囲:\n- 表示のみ。保存ロジックには未介入。\n\n検証:\n- /ui/plans で既存プランの表示を確認（JST表記、cutover/window/policy 表示）。