### PR TITLE
Planning Hub P1: P-01/02/03/04/05/06/15/16/18/19/20

### DIFF
--- a/app/runs_api.py
+++ b/app/runs_api.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+import logging
+from fastapi import Body
+from fastapi.responses import JSONResponse
+
+from app.api import app
+
+
+@app.post("/runs")
+def post_runs(body: Dict[str, Any] = Body(...)):
+    """Run API アダプタ（P-16 一時実装）
+    - pipeline='integrated' を既存の plans/integrated/run or planning job に委譲
+    - async=true の場合はジョブ投入、false（既定）は同期実行
+    返却:
+      - 同期: {status:'succeeded', run_type:'plan', version_id, artifacts, location}
+      - 非同期: {status:'queued', job_id, location}
+    """
+    pipeline = (body.get("pipeline") or "integrated").lower()
+    is_async = bool(body.get("async") or False)
+    options: Dict[str, Any] = body.get("options") or {}
+
+    if pipeline not in ("integrated",):
+        return JSONResponse(status_code=400, content={"detail": "unsupported pipeline"})
+
+    if is_async:
+        # ジョブ投入（/planning/run_job 相当）
+        try:
+            from app.jobs import JOB_MANAGER
+
+            params = {
+                "input_dir": options.get("input_dir") or "samples/planning",
+                "out_dir": options.get("out_dir"),
+                "weeks": options.get("weeks") or 4,
+                "round_mode": options.get("round_mode") or "int",
+                "lt_unit": options.get("lt_unit") or "day",
+                "version_id": options.get("version_id") or "",
+                "cutover_date": options.get("cutover_date"),
+                "recon_window_days": options.get("recon_window_days"),
+                "anchor_policy": options.get("anchor_policy"),
+                "calendar_mode": options.get("calendar_mode"),
+                "max_adjust_ratio": options.get("max_adjust_ratio"),
+                "carryover": options.get("carryover"),
+                "carryover_split": options.get("carryover_split"),
+                "apply_adjusted": bool(options.get("apply_adjusted") or False),
+                "tol_abs": options.get("tol_abs"),
+                "tol_rel": options.get("tol_rel"),
+                "blend_split_next": options.get("blend_split_next"),
+                "blend_weight_mode": options.get("blend_weight_mode"),
+            }
+            job_id = JOB_MANAGER.submit_planning(params)
+            try:
+                logging.info(
+                    "run_queued",
+                    extra={
+                        "event": "run_queued",
+                        "job_id": job_id,
+                        "pipeline": pipeline,
+                    },
+                )
+            except Exception:
+                pass
+            return {
+                "status": "queued",
+                "job_id": job_id,
+                "location": f"/ui/jobs/{job_id}",
+            }
+        except Exception as e:
+            return JSONResponse(status_code=500, content={"detail": str(e)})
+
+    # 同期実行（/plans/integrated/run 相当）
+    try:
+        from app import plans_api as _plans_api
+
+        payload = {
+            **options,
+        }
+        res = _plans_api.post_plans_integrated_run(payload)
+        try:
+            logging.info(
+                "plan_created",
+                extra={
+                    "event": "plan_created",
+                    "version_id": res.get("version_id"),
+                    "pipeline": pipeline,
+                },
+            )
+        except Exception:
+            pass
+        return {
+            "status": "succeeded",
+            "run_type": "plan",
+            "version_id": res.get("version_id"),
+            "artifacts": res.get("artifacts") or [],
+            "location": f"/ui/plans/{res.get('version_id')}",
+        }
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"detail": str(e)})

--- a/main.py
+++ b/main.py
@@ -91,6 +91,12 @@ try:
 except Exception:
     pass
 
+# runs API (adapter)
+try:
+    from app import runs_api as _runs_api  # noqa: F401
+except Exception:
+    pass
+
 __all__ = ["app", "SimulationInput", "SupplyChainSimulator"]
 
 # Fallback: define /simulation route here when import failed (to avoid 404)

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,9 +30,31 @@
         <a href="/ui/planning">集約/詳細計画</a>
         <a href="/ui/plans">プラン一覧</a>
       </nav>
+      <div id="hubBanner" style="display:none; margin-top:8px;">
+        <article style="padding:8px 12px;">
+          <strong>Planning Hub に移行中:</strong>
+          入口は <a href="/ui/plans">/ui/plans</a> に統合しました（ベータ）。
+          <button id="hubBannerClose" class="secondary" style="float:right;">閉じる</button>
+        </article>
+      </div>
     </header>
     {% block content %}{% endblock %}
   </main>
   {% block scripts %}{% endblock %}
+  <script>
+    (function(){
+      function qs(id){ return document.getElementById(id); }
+      function show(){ var el = qs('hubBanner'); if (el) el.style.display=''; }
+      function hide(){ var el = qs('hubBanner'); if (el) el.style.display='none'; }
+      try {
+        var hidden = localStorage.getItem('hideHubBanner') === '1';
+        if (!hidden) {
+          show();
+        }
+        var btn = qs('hubBannerClose');
+        if (btn) btn.addEventListener('click', function(){ localStorage.setItem('hideHubBanner','1'); hide(); });
+      } catch(e) { show(); }
+    })();
+  </script>
 </body>
 </html>

--- a/templates/plans.html
+++ b/templates/plans.html
@@ -2,6 +2,58 @@
 {% block content %}
 <section>
   <h2>プランバージョン一覧</h2>
+  <details open>
+    <summary>新規Plan作成（統合Run）</summary>
+    <form method="post" action="/ui/plans/run">
+      <div class="grid" style="align-items:end;">
+        <label>input_dir<input type="text" name="input_dir" value="samples/planning"></label>
+        <label>weeks<input type="number" name="weeks" min="1" value="4"></label>
+        <label>lt_unit
+          <select name="lt_unit">
+            <option value="day" selected>day</option>
+            <option value="week">week</option>
+          </select>
+        </label>
+        <label>cutover_date<input type="date" name="cutover_date"></label>
+        <label>recon_window_days<input type="number" name="recon_window_days" min="0"></label>
+        <label>anchor_policy
+          <select name="anchor_policy">
+            <option value="">(未指定)</option>
+            <option value="DET_near">DET_near</option>
+            <option value="AGG_far">AGG_far</option>
+            <option value="blend">blend</option>
+          </select>
+        </label>
+        <label>tol_abs<input type="number" step="0.000001" name="tol_abs" placeholder="既定=1e-6"></label>
+        <label>tol_rel<input type="number" step="0.000001" name="tol_rel" placeholder="既定=1e-6"></label>
+        <label>calendar_mode
+          <select name="calendar_mode">
+            <option value="">(未指定)</option>
+            <option value="simple">simple</option>
+            <option value="iso">iso</option>
+          </select>
+        </label>
+        <label>carryover
+          <select name="carryover">
+            <option value="">(未指定)</option>
+            <option value="auto">auto</option>
+            <option value="prev">prev</option>
+            <option value="next">next</option>
+            <option value="both">both</option>
+          </select>
+        </label>
+        <label>carryover_split<input type="number" min="0" max="1" step="0.05" name="carryover_split"></label>
+        <label>apply_adjusted<input type="checkbox" name="apply_adjusted" value="1"></label>
+      </div>
+      <button type="submit">Run（作成）</button>
+      <p class="mono">参考: 従来の実行は <a href="/ui/planning" target="_blank">/ui/planning</a></p>
+    </form>
+  </details>
+
+  <div style="display:flex; gap:8px; align-items:center; margin:8px 0;">
+    <input id="q" type="search" placeholder="検索（version/status/policy）" />
+    <small class="mono" id="meta"></small>
+  </div>
   {% if plans and plans|length > 0 %}
   <table>
     <thead>
@@ -67,6 +119,24 @@ document.addEventListener('DOMContentLoaded', function(){
     var txt = fmtJst(ms);
     if (txt) td.textContent = txt;
   });
+  var q = document.getElementById('q');
+  var meta = document.getElementById('meta');
+  var rows = Array.from(document.querySelectorAll('tbody tr'));
+  function apply(){
+    var s = (q && q.value || '').toLowerCase().trim();
+    var vis = 0;
+    rows.forEach(function(tr){
+      var txt = tr.textContent.toLowerCase();
+      var ok = !s || txt.indexOf(s) >= 0;
+      tr.style.display = ok ? '' : 'none';
+      if (ok) vis++;
+    });
+    if (meta) meta.textContent = vis + ' / ' + rows.length;
+  }
+  if (q) {
+    q.addEventListener('input', apply);
+    apply();
+  }
 });
 </script>
 {% endblock %}

--- a/templates/plans_detail.html
+++ b/templates/plans_detail.html
@@ -7,6 +7,13 @@
     <article><mark>エラー</mark><pre class="mono">{{ error }}</pre></article>
   {% else %}
     <p class="mono">version_id={{ version_id }}</p>
+    <nav style="display:flex; gap:8px; flex-wrap:wrap; margin:8px 0;">
+      <a role="button" class="secondary" data-tab="overview">Overview</a>
+      <a role="button" class="secondary" data-tab="execute">Execute</a>
+      <a role="button" class="secondary" data-tab="results">Results</a>
+      <a role="button" class="secondary" data-tab="diff">Diff</a>
+    </nav>
+    <div id="tab-execute" class="tab-pane" style="display:none;">
     <details open>
       <summary>再整合（パラメータ指定）</summary>
       <form method="post" action="/ui/plans/{{ version_id }}/reconcile">
@@ -54,6 +61,80 @@
       </form>
     </details>
 
+    <details>
+      <summary>統合Run（新規バージョン作成）</summary>
+      <form method="post" action="/ui/plans/run">
+        <div class="grid" style="align-items:end;">
+          <label>input_dir<input type="text" name="input_dir" value="samples/planning"></label>
+          <label>weeks<input type="number" name="weeks" min="1" value="4"></label>
+          <label>lt_unit
+            <select name="lt_unit">
+              <option value="day" selected>day</option>
+              <option value="week">week</option>
+            </select>
+          </label>
+          <label>cutover_date<input type="date" name="cutover_date"></label>
+          <label>recon_window_days<input type="number" name="recon_window_days" min="0"></label>
+          <label>anchor_policy
+            <select name="anchor_policy">
+              <option value="">(未指定)</option>
+              <option value="DET_near">DET_near</option>
+              <option value="AGG_far">AGG_far</option>
+              <option value="blend">blend</option>
+            </select>
+          </label>
+          <label>tol_abs<input type="number" step="0.000001" name="tol_abs" placeholder="既定=1e-6"></label>
+          <label>tol_rel<input type="number" step="0.000001" name="tol_rel" placeholder="既定=1e-6"></label>
+          <label>calendar_mode
+            <select name="calendar_mode">
+              <option value="">(未指定)</option>
+              <option value="simple">simple</option>
+              <option value="iso">iso</option>
+            </select>
+          </label>
+          <label>carryover
+            <select name="carryover">
+              <option value="">(未指定)</option>
+              <option value="auto">auto</option>
+              <option value="prev">prev</option>
+              <option value="next">next</option>
+              <option value="both">both</option>
+            </select>
+          </label>
+          <label>carryover_split<input type="number" min="0" max="1" step="0.05" name="carryover_split"></label>
+          <label>apply_adjusted<input type="checkbox" name="apply_adjusted" value="1"></label>
+        </div>
+        <button type="submit">Run Now（即時実行）</button>
+      </form>
+      <form method="post" action="/planning/run_job" style="margin-top:8px;">
+        <div class="grid" style="align-items:end;">
+          <label>input_dir<input type="text" name="input_dir" value="samples/planning"></label>
+          <label>weeks<input type="number" name="weeks" min="1" value="4"></label>
+          <label>lt_unit
+            <select name="lt_unit">
+              <option value="day" selected>day</option>
+              <option value="week">week</option>
+            </select>
+          </label>
+          <label>cutover_date<input type="date" name="cutover_date"></label>
+          <label>recon_window_days<input type="number" name="recon_window_days" min="0"></label>
+          <label>anchor_policy
+            <select name="anchor_policy">
+              <option value="">(未指定)</option>
+              <option value="DET_near">DET_near</option>
+              <option value="AGG_far">AGG_far</option>
+              <option value="blend">blend</option>
+            </select>
+          </label>
+          <label>apply_adjusted<input type="checkbox" name="apply_adjusted" value="1"></label>
+        </div>
+        <button type="submit" class="secondary">Queue Job（ジョブ投入）</button>
+        <p class="mono">ジョブ投入後は <a href="/ui/jobs" target="_blank">/ui/jobs</a> で進捗を確認できます。</p>
+      </form>
+    </details>
+    </div>
+
+    <div id="tab-overview" class="tab-pane">
     <details open>
       <summary>要約</summary>
       <table>
@@ -73,7 +154,103 @@
         </tbody>
       </table>
     </details>
+    {% if kpi_preview %}
+    <section style="margin-top:8px;">
+      <h4>MVP: KPIプレビュー</h4>
+      <div class="grid" style="grid-template-columns: repeat(3, minmax(180px, 1fr)); gap:8px;">
+        <article>
+          <header>能力合計</header>
+          <strong class="mono">{{ '%.0f'|format(kpi_preview.capacity_total or 0) }}</strong>
+        </article>
+        <article>
+          <header>負荷合計（adjusted）</header>
+          <strong class="mono">{{ '%.0f'|format(kpi_preview.adjusted_total or 0) }}</strong>
+        </article>
+        <article>
+          <header>能力利用率</header>
+          <strong class="mono">{{ ('%.1f%%'|format(kpi_preview.util_pct)) if kpi_preview.util_pct is not none else '-' }}</strong>
+        </article>
+        <article>
+          <header>spill_in 合計</header>
+          <strong class="mono">{{ '%.0f'|format(kpi_preview.spill_in_total or 0) }}</strong>
+        </article>
+        <article>
+          <header>spill_out 合計</header>
+          <strong class="mono">{{ '%.0f'|format(kpi_preview.spill_out_total or 0) }}</strong>
+        </article>
+        <article>
+          <header>違反件数 before/after</header>
+          <strong class="mono">{{ kpi_preview.viol_before or 0 }} → {{ kpi_preview.viol_after if kpi_preview.viol_after is not none else '-' }}</strong>
+        </article>
+        <article>
+          <header>需要合計（DET）</header>
+          <strong class="mono">{{ '%.0f'|format(kpi_preview.det_demand_total or 0) }}</strong>
+        </article>
+        <article>
+          <header>発注合計（DET supply）</header>
+          <strong class="mono">{{ '%.0f'|format(kpi_preview.det_supply_total or 0) }}</strong>
+        </article>
+        <article>
+          <header>サービスレベル（DET, 推定）</header>
+          <strong class="mono">{{ ('%.1f%%'|format(kpi_preview.sl_pct)) if kpi_preview.sl_pct is not none else '-' }}</strong>
+        </article>
+        <article>
+          <header>欠品合計（DET backlog）</header>
+          <strong class="mono">{{ '%.0f'|format(kpi_preview.det_backlog_total or 0) }}</strong>
+        </article>
+        <article>
+          <header>在庫合計（初期, MRP）</header>
+          <strong class="mono">{{ '%.0f'|format(kpi_preview.inv_initial_total if kpi_preview.inv_initial_total is not none else 0) }}</strong>
+        </article>
+      </div>
+      {% if kpi_preview.window_days %}
+        <p class="mono">window_days={{ kpi_preview.window_days }} ｜ policy={{ kpi_preview.anchor_policy or '(none)' }}</p>
+      {% endif %}
+    </section>
+    {% endif %}
+    <p class="mono">
+      エクスポート: 
+      <a href="/plans/{{ version_id }}/summary" target="_blank">summary.json</a> ｜
+      <a href="/plans/{{ version_id }}/compare.csv?violations_only=true&sort=rel_desc&limit=1000" download>compare.csv</a> ｜
+      <a href="/plans/{{ version_id }}/compare.csv?violations_only=true&sort=abs_desc&limit=1000" download>violations.csv</a> ｜
+      <a href="/plans/{{ version_id }}/carryover.csv" download>carryover.csv</a>
+    </p>
+    </div>
 
+    <div id="tab-results" class="tab-pane" style="display:none;">
+    <details open>
+      <summary>最新Run（base_scenario）</summary>
+      {% if version.base_scenario_id %}
+        {% if latest_runs and latest_runs|length > 0 %}
+          <table>
+            <thead><tr><th>run_id</th><th>started_at</th><th>fill_rate</th><th>profit_total</th><th>リンク</th></tr></thead>
+            <tbody>
+              {% for r in latest_runs %}
+              <tr>
+                <td class="mono">{{ r.run_id }}</td>
+                <td class="mono">{{ r.started_at }}</td>
+                <td class="mono">{{ r.fill_rate }}</td>
+                <td class="mono">{{ r.profit_total }}</td>
+                <td><a class="secondary" href="/ui/runs/{{ r.run_id }}" target="_blank">open</a></td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          {% if latest_run_ids and latest_run_ids|length >= 2 %}
+          <form method="post" action="/ui/compare" style="margin-top:8px; display:flex; gap:8px; align-items:center;">
+            <input type="hidden" name="run_ids" value="{{ latest_run_ids[0] }},{{ latest_run_ids[1] }}">
+            <button type="submit">最新2件を比較</button>
+            <a class="secondary" href="/ui/compare/metrics.csv?run_ids={{ latest_run_ids[0] }},{{ latest_run_ids[1] }}" target="_blank">metrics.csv</a>
+            <a class="secondary" href="/ui/compare/diffs.csv?run_ids={{ latest_run_ids[0] }},{{ latest_run_ids[1] }}&threshold=5" target="_blank">diffs.csv (±5%)</a>
+          </form>
+          {% endif %}
+        {% else %}
+          <p>該当シナリオのRunが見つかりません。<a href="/ui/runs" target="_blank">/ui/runs</a> を参照してください。</p>
+        {% endif %}
+      {% else %}
+        <p>プランに base_scenario_id が未設定です。</p>
+      {% endif %}
+    </details>
     {% if weekly_summary %}
     <details>
       <summary>能力サマリ（weekly_summary）</summary>
@@ -102,6 +279,7 @@
       </table>
     </details>
     {% endif %}
+    </div>
 
     {% if deltas %}
     <details open>
@@ -162,6 +340,7 @@
     </details>
     {% endif %}
 
+    <div id="tab-diff" class="tab-pane" style="display:none;">
     {% if deltas_adj %}
     <details>
       <summary>after 差分（先頭50件）</summary>
@@ -220,9 +399,10 @@
       </script>
     </details>
     {% endif %}
+    </div>
   {% endif %}
 </section>
-<section>
+<section id="chart-section" style="display:none;">
   <h3>可視化</h3>
   <canvas id="chartSpillZonePlan" height="100"></canvas>
   <canvas id="chartCapacityPlan" height="100" style="margin-top:16px"></canvas>
@@ -272,8 +452,35 @@
         const c = ctx.getContext('2d'); c.fillText('Chart.js not loaded',10,20);
       }
     }
-    makeSpill();
-    makeCapacity();
+    // 遅延描画: Resultsタブで描画
+    window.__renderCharts = function(){ try{ makeSpill(); makeCapacity(); }catch(e){} };
+  })();
+</script>
+<script>
+  // タブ切替
+  (function(){
+    function activate(tab){
+      ['overview','execute','results','diff'].forEach(function(k){
+        var el = document.getElementById('tab-'+k);
+        if (el) el.style.display = (k===tab)?'':'none';
+      });
+      var chartSec = document.getElementById('chart-section');
+      if (chartSec) chartSec.style.display = (tab==='results')? '' : 'none';
+      if (tab==='results' && typeof window.__renderCharts==='function') { window.__renderCharts(); }
+      document.querySelectorAll('nav [data-tab]').forEach(function(a){
+        a.classList.toggle('contrast', a.getAttribute('data-tab')===tab);
+      });
+      try { localStorage.setItem('plan_detail_tab', tab); } catch(e){}
+    }
+    document.addEventListener('DOMContentLoaded', function(){
+      var saved = null;
+      try { saved = localStorage.getItem('plan_detail_tab'); } catch(e){}
+      var init = saved || 'overview';
+      activate(init);
+      document.querySelectorAll('nav [data-tab]').forEach(function(a){
+        a.addEventListener('click', function(){ activate(a.getAttribute('data-tab')); });
+      });
+    });
   })();
 </script>
 {% endblock %}


### PR DESCRIPTION
このPRはPlanning Hub UX計画（docs/PLANNING-HUB-UX-PLAN.md）に基づくP1範囲の実装です。\n- P-01/02: /ui/plans に作成フォームと検索\n- P-03/04: /ui/plans/{id} にタブ骨格/Execute統合\n- P-05: 最新Run表示＋Compare導線\n- P-06: Home→/ui/plans リダイレクト＆Hubバナー\n- P-15/16: Run API仕様ドラフトと /runs アダプタ\n- P-18: KPIプレビュー（能力/負荷/利用率/スピル/違反/需要・発注・SL・在庫初期）\n- P-19: 計測イベントログ\n- P-20: README/計画書更新\n\n検証: READMEの手順、/ui/plans 動線、/runs 同期/非同期、各タブ表示。