### PR TITLE
docs: CHANGELOGにアクセシビリティ改善と計画書整合を追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- feat(ui/plans): Planning Hub 詳細のアクセシビリティ改善（aria-label追加）
+- docs(planning): PLANNING-HUB-UX-PLAN のWBS整合（P-23/P-24 完了）と進捗追記
+
 ## v0.5.0 (2025-09-07)
 
 - Planning Hub P2 の安定リリース


### PR DESCRIPTION
CHANGELOGのUnreleasedに以下を追記しました:\n- feat(ui/plans): Planning Hub 詳細のアクセシビリティ改善（aria-label追加）\n- docs(planning): PLANNING-HUB-UX-PLAN のWBS整合（P-23/P-24 完了）と進捗追記\n\n自動マージ（squash）を有効化します。