### PR TITLE
feat/psi weights lockui ja

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,6 +839,29 @@ sequenceDiagram
 - 表示項目: ts（ISO8601）、level（aggregate|det）、type（edit|lock）、key(s)、fields/lock
 - 保存対象: plan_artifacts の `psi_audit.json` に追記（最大1万件を保持）
 
+#### 分配オプション（Aggregate→Detail）
+- 目的: Aggregate（family×period）で編集した需要/供給/バックログをDetail（sku×week）へ比例配分で投影
+- 設定:
+  - weight_mode: current（現値比例, 既定）/ equal（均等）/ demand / supply_plan
+  - 丸め: demand/supply_plan/backlog 各フィールドに step を指定可（最寄りの倍数に丸め、総和は再スケール）
+- 注意:
+  - detの行ロック/セルロックは配分対象外（アンロック分へ再正規化）
+  - 週→月の紐付けはISO週（週の月曜日）で月を判定
+
+#### ロック（行/セル）
+- 行ロック: PSIタブの鍵チェック＋ロックモード（lock/unlock/toggle）で保存
+- セルロック: セルを選択→[Lock cell]/[Unlock cell]
+- 内部キー例: `det:week=2025-W01,sku=SKU1`（行）、`det:week=2025-W01,sku=SKU1:field=demand`（セル）
+
+#### 承認ワークフロー（MVP）
+- APIキー（X-API-Key）
+  - 環境変数 `API_KEY_VALUE` を設定すると、PATCH/approve/reconcile にAPIキーが必須
+  - UIは `localStorage.api_key` を自動付与
+- 手順:
+  - Submit: PSIタブでメモを付けて提出（/psi/submit）→ 状態は pending
+  - Approve: 承認（/psi/approve）。チェックONで承認後に自動整合（差分ログ/オプション反映）
+  - 状態は `psi_state.json` に保存、監査も `psi_audit.json` に追記
+
 ### 計画プロセス（PSIを含む）Mermaid
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -831,8 +831,13 @@ sequenceDiagram
 - 再整合: 「再整合オプション」（必要時）を設定し「適用して整合を実行」
   - 既定: reconcile_levels（before差分）を更新
   - adjusted: apply_adjusted をON＋anchor_policy と cutover_date を指定（windowやtoleranceも任意）
-  - MRP: recalc_mrp をON（apply_adjustedと併用）。lt_unit/weeks を必要に応じて指定
+- MRP: recalc_mrp をON（apply_adjustedと併用）。lt_unit/weeks を必要に応じて指定
   - 実行後: Diff/Validate で結果を確認。Artifactsに *_adjusted.json が追加されます
+
+#### 監査ログ（PSIタブ）
+- 監査セクションを開いて、level/q/limit を指定→「再読込」
+- 表示項目: ts（ISO8601）、level（aggregate|det）、type（edit|lock）、key(s)、fields/lock
+- 保存対象: plan_artifacts の `psi_audit.json` に追記（最大1万件を保持）
 
 ### 計画プロセス（PSIを含む）Mermaid
 

--- a/templates/plans_detail.html
+++ b/templates/plans_detail.html
@@ -112,6 +112,8 @@
             <option value="toggle">toggle</option>
           </select>
         </label>
+        <button id="psiLockCell" type="button" class="secondary">Lock cell</button>
+        <button id="psiUnlockCell" type="button" class="secondary">Unlock cell</button>
         <small class="mono" id="psiMeta"></small>
       </div>
       <div style="overflow:auto;">
@@ -163,6 +165,29 @@
         <p class="mono">注: adjusted 実行には anchor_policy と cutover_date の指定が必要です。MRP再計算は apply_adjusted と組み合わせます。</p>
       </details>
       <details>
+        <summary>分配オプション（Aggregate→Detail）</summary>
+        <div class="grid" style="align-items:end;">
+          <label>weight_mode
+            <select id="psiWeight">
+              <option value="current" selected>current（現値比例）</option>
+              <option value="equal">equal（均等）</option>
+              <option value="demand">demandに比例</option>
+              <option value="supply_plan">supply_planに比例</option>
+            </select>
+          </label>
+          <label>round demand
+            <input type="number" id="psiRoundDemand" placeholder="step（例: 1）">
+          </label>
+          <label>round supply_plan
+            <input type="number" id="psiRoundSupply" placeholder="step（例: 1）">
+          </label>
+          <label>round backlog
+            <input type="number" id="psiRoundBacklog" placeholder="step（例: 1）">
+          </label>
+        </div>
+        <p class="mono">注: Aggregateを保存した時に適用。step指定時は最寄りの倍数に丸めます（総和は再スケール）。</p>
+      </details>
+      <details>
         <summary>CSVインポート（ヘッダ付き, 既定列のみ）</summary>
         <p class="mono">aggregate: period,family,demand,supply,backlog ｜ det: week,sku,demand,supply_plan,backlog,on_hand_start,on_hand_end</p>
         <textarea id="psiCsvText" rows="6" placeholder="CSVを貼り付け"></textarea>
@@ -188,12 +213,27 @@
           <table id="tblPSIAudit" style="min-width:960px;"></table>
         </div>
       </details>
+      <details>
+        <summary>承認ワークフロー</summary>
+        <div style="display:flex; gap:8px; align-items:end; flex-wrap:wrap; margin:6px 0;">
+          <label>note<input id="psiSubmitNote" type="text" placeholder="提出メモ"></label>
+          <button id="psiSubmit" type="button">Submit（提出）</button>
+          <label><input type="checkbox" id="psiApproveRecon"> 承認後に整合実行</label>
+          <button id="psiApprove" type="button" class="secondary">Approve（承認）</button>
+          <small class="mono">注: ApproveにはAPIキーが必要です（localStorage.api_key）。</small>
+        </div>
+      </details>
       <p class="mono" id="psiNote">注: PSIの編集は一時オーバレイとして保存され、[適用して整合を実行]で差分ログが更新されます（MVP）。</p>
     </details>
     <script>
     (function(){
       const ver = {{ version_id | tojson | safe }};
       const tbl = document.getElementById('tblPSI');
+      function getHeaders(){
+        const h = {'Content-Type':'application/json'};
+        try { const k = localStorage.getItem('api_key') || ''; if (k) h['X-API-Key'] = k; } catch {}
+        return h;
+      }
       const levelEl = document.getElementById('psiLevel');
       const qEl = document.getElementById('psiQ');
       const limEl = document.getElementById('psiLimit');
@@ -235,6 +275,7 @@
         tbl.innerHTML = thead + '<tbody>'+body+'</tbody>';
         // 変更検知
         tbl.querySelectorAll('td[contenteditable]').forEach(td=>{
+          td.addEventListener('focus', ev=>{ window.__psiLastCell = ev.currentTarget; });
           td.addEventListener('blur', ev=>{
             const el = ev.currentTarget; const key = el.getAttribute('data-key'); const f = el.getAttribute('data-field');
             const before = el.getAttribute('data-value')||''; const after = el.textContent.trim();
@@ -272,8 +313,23 @@
         }
         const edits = Array.from(grouped.values());
         const lock = lockEl.value || undefined;
+        // 分配オプション（aggregate時のみ）
+        let distribute = undefined;
+        if (level === 'aggregate'){
+          const wm = document.getElementById('psiWeight');
+          const rd = document.getElementById('psiRoundDemand');
+          const rs = document.getElementById('psiRoundSupply');
+          const rb = document.getElementById('psiRoundBacklog');
+          const round = {};
+          if (rd && rd.value) round['demand'] = { mode:'nearest', step: Number(rd.value) };
+          if (rs && rs.value) round['supply_plan'] = { mode:'nearest', step: Number(rs.value) };
+          if (rb && rb.value) round['backlog'] = { mode:'nearest', step: Number(rb.value) };
+          distribute = { weight_mode: (wm && wm.value)||'current', round };
+        }
         if (edits.length===0 && !lock){ return; }
-        const res = await fetch(`/plans/${ver}/psi`, { method:'PATCH', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ level, edits, lock }) });
+        const body = { level, edits, lock };
+        if (distribute) body['distribute'] = distribute;
+        const res = await fetch(`/plans/${ver}/psi`, { method:'PATCH', headers:getHeaders(), body: JSON.stringify(body) });
         if (!res.ok){ alert('save failed'); return; }
         pending.clear(); await load();
       }
@@ -305,7 +361,7 @@
         body.carryover = cov && cov.value ? cov.value : undefined;
         body.carryover_split = csv && csv.value!=='' ? Number(csv.value) : undefined;
         body.input_dir = idir && idir.value ? idir.value : 'samples/planning';
-        const res = await fetch(`/plans/${ver}/psi/reconcile`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
+        const res = await fetch(`/plans/${ver}/psi/reconcile`, { method:'POST', headers:getHeaders(), body: JSON.stringify(body) });
         if (!res.ok){ alert('reconcile failed'); return; }
         const js = await res.json();
         alert('reconciled: violations='+(js.summary && (js.summary.violations||js.summary.tol_violations||0)));
@@ -313,6 +369,16 @@
       document.getElementById('psiReload')?.addEventListener('click', load);
       document.getElementById('psiSave')?.addEventListener('click', save);
       document.getElementById('psiRecon')?.addEventListener('click', recon);
+      function lockCell(mode){
+        const el = window.__psiLastCell; if (!el){ alert('セルを選択してください'); return; }
+        const key = el.getAttribute('data-key'); const f = el.getAttribute('data-field');
+        if (!key || !f){ return; }
+        const lock_keys = [`${key}:field=${f}`];
+        fetch(`/plans/${ver}/psi`, { method:'PATCH', headers:getHeaders(), body: JSON.stringify({ level: levelEl.value, edits: [], lock: mode, lock_keys }) })
+          .then(()=> load());
+      }
+      document.getElementById('psiLockCell')?.addEventListener('click', ()=> lockCell('lock'));
+      document.getElementById('psiUnlockCell')?.addEventListener('click', ()=> lockCell('unlock'));
       document.getElementById('psiCsvApply')?.addEventListener('click', async function(){
         const level = levelEl.value;
         const ta = document.getElementById('psiCsvText'); const txt = (ta && ta.value)||''; if(!txt.trim()) return;
@@ -334,7 +400,7 @@
             edits.push({ key, fields });
           }
         }
-        const res = await fetch(`/plans/${ver}/psi`, { method:'PATCH', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ level, edits }) });
+        const res = await fetch(`/plans/${ver}/psi`, { method:'PATCH', headers:getHeaders(), body: JSON.stringify({ level, edits }) });
         if (!res.ok){ alert('CSV適用に失敗しました'); return; }
         ta.value=''; await load();
       });
@@ -359,6 +425,18 @@
         tblA.innerHTML = head + '<tbody>'+body+'</tbody>';
       }
       document.getElementById('psiAuditReload')?.addEventListener('click', loadAudit);
+      document.getElementById('psiSubmit')?.addEventListener('click', async function(){
+        const note = (document.getElementById('psiSubmitNote')?.value)||'';
+        const res = await fetch(`/plans/${ver}/psi/submit`, { method:'POST', headers:getHeaders(), body: JSON.stringify({ note }) });
+        if (!res.ok){ alert('submit failed'); return; }
+        alert('submitted');
+      });
+      document.getElementById('psiApprove')?.addEventListener('click', async function(){
+        const auto = !!(document.getElementById('psiApproveRecon')?.checked);
+        const res = await fetch(`/plans/${ver}/psi/approve`, { method:'POST', headers:getHeaders(), body: JSON.stringify({ auto_reconcile: auto }) });
+        if (!res.ok){ alert('approve failed'); return; }
+        alert('approved');
+      });
       // チェックでロックトグル（即時反映ではなく保存時にlockModeが指定されている場合に反映）
       tbl.addEventListener('change', ev=>{
         const t = ev.target; if (!t || !t.classList || !t.classList.contains('psi-lock')) return;

--- a/templates/plans_detail.html
+++ b/templates/plans_detail.html
@@ -114,6 +114,7 @@
         </label>
         <button id="psiLockCell" type="button" class="secondary">Lock cell</button>
         <button id="psiUnlockCell" type="button" class="secondary">Unlock cell</button>
+        <button id="psiUnlockAll" type="button" class="secondary">Unlock all</button>
         <small class="mono" id="psiMeta"></small>
       </div>
       <div style="overflow:auto;">
@@ -163,6 +164,14 @@
           <label>input_dir<input type="text" id="psiInputDir" value="samples/planning"></label>
         </div>
         <p class="mono">注: adjusted 実行には anchor_policy と cutover_date の指定が必要です。MRP再計算は apply_adjusted と組み合わせます。</p>
+      </details>
+      <details>
+        <summary>Weights（CSVインポート）</summary>
+        <p class="mono">ヘッダ付き: key,weight（または week,sku,weight）。key例: det:week=2025-W01,sku=SKU1</p>
+        <textarea id="psiWeightsCsv" rows="4" placeholder="key,weight\ndet:week=2025-W01,sku=SKU1,1\ndet:week=2025-W01,sku=SKU2,2"></textarea>
+        <div>
+          <button id="psiWeightsApply" type="button">Weightsを適用</button>
+        </div>
       </details>
       <details>
         <summary>分配オプション（Aggregate→Detail）</summary>
@@ -261,10 +270,10 @@
         const body = rows.map(r=>{
           const k = mkKey(level,r);
           const rowLocked = locks.has(k);
-          const tds = cols.map(c=>{
-            const val = r[c.k];
-            const ro = c.ro || rowLocked;
-            const attr = ro? 'data-ro="1"' : 'contenteditable';
+      const tds = cols.map(c=>{
+          const val = r[c.k];
+          const ro = c.ro || rowLocked || locks.has(`${k}:field=${c.k}`);
+          const attr = ro? 'data-ro="1"' : 'contenteditable';
             const cls = ro? 'class="ro"' : '';
             const dv = fmt(val);
             return `<td ${attr} ${cls} data-field="${c.k}" data-key="${k}" data-value="${dv}">${dv}</td>`;
@@ -379,6 +388,12 @@
       }
       document.getElementById('psiLockCell')?.addEventListener('click', ()=> lockCell('lock'));
       document.getElementById('psiUnlockCell')?.addEventListener('click', ()=> lockCell('unlock'));
+      document.getElementById('psiUnlockAll')?.addEventListener('click', async ()=>{
+        const keys = Array.from(locks);
+        if (!keys.length) return;
+        await fetch(`/plans/${ver}/psi`, { method:'PATCH', headers:getHeaders(), body: JSON.stringify({ level: levelEl.value, edits: [], lock: 'unlock', lock_keys: keys }) });
+        await load();
+      });
       document.getElementById('psiCsvApply')?.addEventListener('click', async function(){
         const level = levelEl.value;
         const ta = document.getElementById('psiCsvText'); const txt = (ta && ta.value)||''; if(!txt.trim()) return;
@@ -436,6 +451,13 @@
         const res = await fetch(`/plans/${ver}/psi/approve`, { method:'POST', headers:getHeaders(), body: JSON.stringify({ auto_reconcile: auto }) });
         if (!res.ok){ alert('approve failed'); return; }
         alert('approved');
+      });
+      document.getElementById('psiWeightsApply')?.addEventListener('click', async function(){
+        const ta = document.getElementById('psiWeightsCsv'); const txt = (ta && ta.value) || '';
+        if (!txt.trim()) return;
+        const res = await fetch(`/plans/${ver}/psi/weights`, { method:'POST', headers:getHeaders(), body: JSON.stringify({ csv: txt }) });
+        if (!res.ok){ alert('weights failed'); return; }
+        alert('weights applied');
       });
       // チェックでロックトグル（即時反映ではなく保存時にlockModeが指定されている場合に反映）
       tbl.addEventListener('change', ev=>{

--- a/templates/plans_detail.html
+++ b/templates/plans_detail.html
@@ -170,6 +170,24 @@
           <button id="psiCsvApply" type="button">CSVを適用（保存）</button>
         </div>
       </details>
+      <details>
+        <summary>監査ログ（直近）</summary>
+        <div style="display:flex; gap:8px; align-items:end; flex-wrap:wrap; margin:6px 0;">
+          <label>level
+            <select id="psiAuditLevel">
+              <option value="">(全て)</option>
+              <option value="aggregate">aggregate</option>
+              <option value="det">det</option>
+            </select>
+          </label>
+          <label>q<input id="psiAuditQ" type="search" placeholder="フィルタ（テキスト）"></label>
+          <label>limit<input id="psiAuditLimit" type="number" min="10" value="200"></label>
+          <button id="psiAuditReload" type="button">再読込</button>
+        </div>
+        <div style="overflow:auto; max-height:320px;">
+          <table id="tblPSIAudit" style="min-width:960px;"></table>
+        </div>
+      </details>
       <p class="mono" id="psiNote">注: PSIの編集は一時オーバレイとして保存され、[適用して整合を実行]で差分ログが更新されます（MVP）。</p>
     </details>
     <script>
@@ -320,6 +338,27 @@
         if (!res.ok){ alert('CSV適用に失敗しました'); return; }
         ta.value=''; await load();
       });
+      async function loadAudit(){
+        const level = document.getElementById('psiAuditLevel')?.value || '';
+        const q = (document.getElementById('psiAuditQ')?.value||'').trim();
+        const limit = Number(document.getElementById('psiAuditLimit')?.value||'200');
+        const url = new URL(`/plans/${ver}/psi/audit`, location.origin);
+        if (level) url.searchParams.set('level', level); if (q) url.searchParams.set('q', q); url.searchParams.set('limit', String(limit));
+        const res = await fetch(url.toString()); if (!res.ok) return;
+        const js = await res.json();
+        const rows = js.events||[];
+        const tblA = document.getElementById('tblPSIAudit'); if(!tblA) return;
+        const head = '<thead><tr><th>ts</th><th>level</th><th>type</th><th>key(s)</th><th>fields/lock</th></tr></thead>';
+        const body = rows.map(r=>{
+          const ts = r.ts? new Date(Number(r.ts)).toISOString(): '';
+          const typ = r.lock ? 'lock' : 'edit';
+          const keys = r.keys? JSON.stringify(r.keys): JSON.stringify(r.key);
+          const meta = r.lock? r.lock : JSON.stringify(r.fields);
+          return `<tr><td class="mono">${ts}</td><td class="mono">${r.level||''}</td><td class="mono">${typ}</td><td class="mono">${keys||''}</td><td class="mono">${meta||''}</td></tr>`;
+        }).join('');
+        tblA.innerHTML = head + '<tbody>'+body+'</tbody>';
+      }
+      document.getElementById('psiAuditReload')?.addEventListener('click', loadAudit);
       // チェックでロックトグル（即時反映ではなく保存時にlockModeが指定されている場合に反映）
       tbl.addEventListener('change', ev=>{
         const t = ev.target; if (!t || !t.classList || !t.classList.contains('psi-lock')) return;


### PR DESCRIPTION
- **feat: PSI監査ログの可視化を追加（/plans/{id}/psi/audit とUIセクション）**
- **docs: PSI監査ログの使い方をREADMEに追記**
- **feat: PSI分配の拡張（重み付け/丸め）、セルロックUI、簡易RBAC/承認フローを追加**
- **docs: PSI 分配オプション/ロック/承認ワークフローの使い方をREADMEに追記**
- **feat: PSI 分配にカスタム重み（weights）と丸めmin対応、セルロック可視化・一括解除、Weights CSVインポートを追加**
